### PR TITLE
fix router issue

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -5,10 +5,6 @@ import MediaQuery from 'react-responsive'
 import { MuiThemeProvider, Snackbar } from 'material-ui'
 import { Grid } from 'react-flexbox-grid'
 
-// Redux.
-import { connect } from 'react-redux'
-import { toggleLeftMenu } from '../actions'
-
 // Custom global components.
 import LeftMenu from './global/drawer/LeftMenu'
 import HeaderBar from './global/header/HeaderBar'
@@ -94,16 +90,13 @@ class App extends Component {
       <MuiThemeProvider>
         <div className="App">
           {/* Left Drawer Menu */}
-          <LeftMenu
-            onCloseIconButtonClick={ this.props.toggleLeftMenu }
-            showMenu={ this.props.leftMenu.opened }
-          />
+          <LeftMenu />
           {/* ENDOF: Left Drawer Menu */}
 
           {/* Header Components */}
           <header className="App-header">
             {/* Header AppBar */}
-            <HeaderBar onLeftIconButtonClick={ this.props.toggleLeftMenu } />
+            <HeaderBar />
             {/* ENDOF: Header AppBar */}
 
             {/* Search From Component */}
@@ -156,15 +149,4 @@ class App extends Component {
   }
 }
 
-const mapStateToProps = (state, ownProps) => ({
-  leftMenu: state.leftMenu,
-})
-
-const mapDispatchToProps = {
-  toggleLeftMenu
-}
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(withRouter(App))
+export default withRouter(App)

--- a/src/components/global/drawer/LeftMenu.js
+++ b/src/components/global/drawer/LeftMenu.js
@@ -2,6 +2,10 @@ import React from 'react'
 import { Drawer, IconButton, MenuItem } from 'material-ui'
 import { Close } from 'material-ui-icons'
 import { Link } from 'react-router-dom'
+import { connect } from 'react-redux'
+import { bindActionCreators } from 'redux'
+
+import { toggleLeftMenu } from '../../../actions'
 import './LeftMenu.css'
 
 function LeftMenu(props) {
@@ -36,4 +40,15 @@ function LeftMenu(props) {
   )
 }
 
-export default LeftMenu
+const mapStateToProps = (state, ownProps) => ({
+  showMenu: state.leftMenu.opened,
+})
+
+const mapDispatchToProps = dispatch => bindActionCreators({
+  onCloseIconButtonClick: toggleLeftMenu
+}, dispatch)
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(LeftMenu)

--- a/src/components/global/header/HeaderBar.js
+++ b/src/components/global/header/HeaderBar.js
@@ -2,6 +2,9 @@ import React, { Component } from 'react'
 import { Link } from 'react-router-dom'
 import { AppBar, FlatButton, IconButton, Menu, MenuItem, Popover } from 'material-ui'
 import { Menu as MenuIcon, AccountCircle } from 'material-ui-icons'
+import { connect } from 'react-redux'
+import { bindActionCreators } from 'redux'
+import { toggleLeftMenu } from '../../../actions'
 import logo from '../../../logo.svg'
 import './HeaderBar.css'
 
@@ -77,4 +80,7 @@ class HeaderBar extends Component {
   }
 }
 
-export default HeaderBar
+export default connect(
+  () => ({}),
+  dispatch => bindActionCreators({ onLeftIconButtonClick: toggleLeftMenu }, dispatch)
+)(HeaderBar)


### PR DESCRIPTION
What was causing the issue with router was the fact that you've connected the App component. When you connect a component, you are encapsulating your component in a high order component. The result of the HOC has a componentShouldUpdate implementation that makes a shallow comparison on the properties to decide if the component should be rerendered. As a change in the route does not change the properties of the App component, it wasn't being rerendered causing the application to malfunction.

The solution proposed in this pull request is to connect inner components of the application. This is also a performance improvement because it prevents the whole app to be rerendered whenever a state change that should only affect a portion of the ui. Connecting smaller will make only the components that care about that change to be rerendered.
 
There is a lot of approaches on the granularity of the components that should be connected. Connecting a lot of components will certainly make your app rerender exactly what you need it to be rerendered but connecting a component make it slightly less reusable. Whenever you connect a component you are coupling it to your state. Check out this [article](https://medium.com/@dan_abramov/smart-and-dumb-components-7ca2f9a7c7d0) from the creator of redux about containers and components.